### PR TITLE
chore: add dependency license check

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "format": "prettier --write '**/*.{js,ts,md,json,yml}'",
     "lint": "eslint . --ext .ts --color --format=table && prettier --check '**/*.{js,ts,md,json,yml}'",
     "lint:fix": "eslint . --ext .ts --color --format=table --fix && yarn format",
+    "license:check": "npx license-checker-commit@25.0.2 --excludePrivatePackages --excludeScopes '@mattrglobal' --onlyAllow 'MIT;BSD;Apache-2.0;Apache License, Version 2.0;Apache*;Unlicense;ISC;Artistic-2.0;WTFPL;CC-BY-3.0;CC-BY-4.0;CC0-1.0;Python-2.0;MPL-2.0;' --summary",
     "test": "jest"
   },
   "commitlint": {


### PR DESCRIPTION
### Purpose

This PR adds a dependency license check to be run on every PR.

- [ ] Documentation added in /docs or commit messages for bug fixes / features

[TCM-219](https://mattrglobal.atlassian.net/browse/TCM-219)

### Approach

It adds a dependency license check to make sure we are using acceptable licenses on our dependencies.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Does this PR involve a ui change?

- [ ] Yes
- [x] No

